### PR TITLE
Log of all notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv/
 private_key.pem
 database.sqlite
+__pycache__

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Notification test</title>
+  <meta charset="UTF-8" />
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="static/pico.min.css">
+</head>
+<body>
+<main class="container">
+  {% block container %}{% endblock container %}
+</main>
+<script type="text/javascript" src="static/index.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,6 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <title>Notification test</title>
-  <meta charset="UTF-8" />
-  <link rel="manifest" href="manifest.json">
-  <link rel="stylesheet" href="pico.min.css">
-</head>
-<body>
-<main class="container">
+{% extends "base.html" %}
+
+{% block container %}
   <form>
     <p>Status: <span id="loading-text">Loading, waiting for the service worker registration</span></p>
     <button type="button" id="ask-for-notifications">
@@ -27,7 +20,12 @@
     <p><label>Message to notify <input type="text" id="notify-message-input" /></label></p>
     <p><button type="button" id="notify-message">Notify me</button> <span id="notify-message-status"></span></p>
   </form>
-</main>
-<script type="text/javascript" src="index.js"></script>
-</body>
-</html>
+
+  <h2>Historique global</h2>
+  <ul>
+    {% for notification in notifications %}
+      <li>{{ notification }}</li>
+    {% endfor %}
+  </ul>
+{% endblock container %}
+


### PR DESCRIPTION
Not sure if it is useful but I have to play with the page and see how to setup jinja x litestar.

<img width="1488" alt="Capture d’écran, le 2025-04-28 à 14 18 51" src="https://github.com/user-attachments/assets/9b0d60b5-ff98-45c8-a5f6-2e154b9f4779" />

Two things I noticed while doing it:

1. `get_user_by_email` might be more robust with `.first()` (vs. `.one()`) in case there are many entries… but we should not allow that before hand.
2. serving statics through their dedicated folder might be an issue with the standard discoverability of some files like `manifest.json`, to check.