### PR TITLE
Use the uv buildpack on scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,1 +1,2 @@
+https://github.com/dropseed/heroku-buildpack-uv
 https://github.com/Scalingo/python-buildpack

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,3 @@ dev:
 .PHONY: serve
 serve:
 	bin/start.sh
-
-update_deps:
-	uv export --output-file requirements.txt --no-dev --no-emit-project --frozen

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -3,14 +3,6 @@
 PORT="${PORT:-8000}"
 HOSTNAME="${HOSTNAME:-127.0.0.1}"
 
-if ! command -v uv 2>&1 >/dev/null
-then
-  curl -LsSf "https://astral.sh/uv/0.6.13/install.sh" | sh 2>&1
-
-  # Make the uv commands available
-  source "$HOME/.local/bin/env"
-fi
-
 # Only works when developping locally...
 VAPID_PUBLIC_KEY_FILE="public_key.pem"
 VAPID_PRIVATE_KEY_FILE="private_key.pem"


### PR DESCRIPTION
This is how it used to be, but following an update from scalingo, it started failing the deployments.

We'll keep this PR open and try deploying it every now and then to see if/when it works again on scalingo.