### PR TITLE
Use postgres for tests and local dev

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Copy this file to `.env`, then modify it with your local needs.
 # Variables in this file will be auto-loaded when using `make dev`.
-DATABASE_URL="sqlite+aiosqlite:///database.sqlite"
+DATABASE_URL="postgresql+asyncpg://postgres:some_password@localhost:5432/postgres"
 
 #### Svelte configuration for the mobile app.
 PUBLIC_API_PORT=8000

--- a/.env.tests
+++ b/.env.tests
@@ -1,3 +1,0 @@
-# The following env variables are used when running test with `make test`.
-DATABASE_URL="sqlite+aiosqlite:///file:?mode=memory&cache=shared&uri=true"
-

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint-and-format: install
 
 .PHONY: test
 test:
-	uv run --env-file .env.tests pytest
+	uv run --env-file .env pytest
 
 .PHONY: dev
 dev:

--- a/README.md
+++ b/README.md
@@ -163,15 +163,25 @@ The easiest way to run tests is to use the Makefile target:
 make test
 ```
 
+Those tests will be run against a (postgres) database on the same server as the
+one configured for your application, with the `_test` suffix.
+
+So for example if you're using
+`DATABASE_URL="postgresql+asyncpg://postgres:some_password@localhost:5432/postgres"`
+for your application, the tests will be running on
+`DATABASE_URL="postgresql+asyncpg://postgres:some_password@localhost:5432/postgres_test"`.
+
+This test database must be created beforehand.
+
 If you'd rather run the tests manually, copy and paste the command from the Makefile:
 ```
-uv run --env-file .env.tests pytest
+uv run --env-file .env pytest
 ```
 
 
 To run a single test, you would use something like:
 ```
-uv run --env-file .env.tests pytest tests/test_basic.py::test_homepage_title
+uv run --env-file .env pytest tests/test_basic.py::test_homepage_title
 ```
 
 ### Mobile app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -211,12 +211,9 @@ async def list_users(db_session: AsyncSession) -> list[Registration]:
 
 @get("/notifications/{email:str}")
 async def get_notifications(db_session: AsyncSession, email: str) -> list[Notification]:
-    try:
-        user: User = await get_user_by_email(
-            email, db_session, options=selectinload(cast(InstrumentedAttribute, User.notifications))
-        )
-    except NotFoundException:
-        return []
+    user: User = await get_user_by_email(
+        email, db_session, options=selectinload(cast(InstrumentedAttribute, User.notifications))
+    )
     return user.notifications
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def test_webpush() -> WebPush:
 
 @asynccontextmanager
 async def test_db_connection(app: Litestar) -> AsyncGenerator[None, None]:
-    """Database connection for the app."""
+    """Database connection for the app's lifespan."""
     engine = create_async_engine(TEST_DATABASE_URL)
     app.state.engine = engine
 
@@ -59,7 +59,16 @@ def test_client(app) -> Iterator[TestClient[Litestar]]:
 
 @pytest.fixture
 async def test_engine() -> AsyncGenerator[AsyncEngine, None]:
-    """Create a fresh database engine for each test with proper cleanup."""
+    """Create a fresh database engine for each test with proper cleanup.
+
+    This is a duplication of the `test_db_connection` to avoid some bug around event loops:
+
+    https://github.com/litestar-org/litestar/issues/1920#issuecomment-2592572498
+
+    So we create an engine to be used by the `db_session` fixture, created in the context/scope
+    of the tests event loop, instead of using the `app.state.engine`.
+
+    """
     engine = create_async_engine(TEST_DATABASE_URL)
 
     # Create all tables

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,10 +3,10 @@ from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED
 from litestar.testing import TestClient
 from pytest_httpx import HTTPXMock
 
-from app import Notification, Registration
+from app import Notification, Registration, User
 
 
-def test_notifications_empty(test_client: TestClient[Litestar]) -> None:
+async def test_notifications_empty(test_client: TestClient[Litestar]) -> None:
     response = test_client.get("/notifications/test@example.com")
     assert response.status_code == HTTP_200_OK
     assert response.json() == []
@@ -54,3 +54,103 @@ async def test_create_notification_from_test_and_from_app_context(
     assert response.json()[1]["message"] == "Hello notification 2"
     assert response.json()[1]["title"] == "Some notification title"
     assert response.json()[1]["sender"] == "Jane Doe"
+
+
+async def test_database_isolation_test_one(test_client: TestClient[Litestar], db_session) -> None:
+    """Test 1: Create user 'alice@example.com' and verify only this user exists."""
+    # Create a user directly in the test database
+    user = User(email="alice@example.com")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    # Verify this user exists in our test database
+    assert user.id is not None
+    assert user.email == "alice@example.com"
+
+    # Check that only this user exists (no leakage from other tests)
+    from sqlalchemy import select
+
+    all_users = await db_session.exec(select(User))
+    all_users_list = all_users.all()
+    assert len(all_users_list) == 1
+    assert all_users_list[0][0].email == "alice@example.com"
+
+
+async def test_database_isolation_test_two(test_client: TestClient[Litestar], db_session) -> None:
+    """Test 2: Create user 'bob@example.com' and verify only this user exists (no alice)."""
+    # Create a different user directly in the test database
+    user = User(email="bob@example.com")
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    # Verify this user exists in our test database
+    assert user.id is not None
+    assert user.email == "bob@example.com"
+
+    # Check that only this user exists (proving no leakage from test_one)
+    from sqlalchemy import select
+
+    all_users = await db_session.exec(select(User))
+    all_users_list = all_users.all()
+    assert len(all_users_list) == 1
+    assert all_users_list[0][0].email == "bob@example.com"
+    # Importantly, alice@example.com should NOT be here
+
+
+async def test_shared_database_api_and_test_engine(
+    test_client: TestClient[Litestar], db_session, webpushsubscription
+) -> None:
+    """Test that API and test engine share the same database (as discovered)."""
+
+    # 1. Create a user via the API
+    register_data = {"email": "apiuser@example.com", "subscription": webpushsubscription}
+    response = test_client.post("/notification/register", json=register_data)
+    assert response.status_code == HTTP_201_CREATED
+
+    # 2. Create a user directly in the test database
+    test_user = User(email="testuser@example.com")
+    db_session.add(test_user)
+    await db_session.commit()
+    await db_session.refresh(test_user)
+
+    # 3. Verify both users exist in the test database (shared with API)
+    from sqlalchemy import select
+
+    all_users = await db_session.exec(select(User))
+    all_users_list = all_users.all()
+    assert len(all_users_list) == 2
+    users = [row[0] for row in all_users_list]
+    emails = {user.email for user in users}
+    assert emails == {"apiuser@example.com", "testuser@example.com"}
+
+    # 4. Verify API user exists via API calls
+    response = test_client.get("/notifications/apiuser@example.com")
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == []  # User exists (no 404) but has no notifications
+
+    # 5. Verify test user is also accessible via API (shared database)
+    response = test_client.get("/notifications/testuser@example.com")
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == []  # User exists, no notifications
+
+    # 6. Create a notification for the API-created user via test database
+    api_user = next(user for user in users if user.email == "apiuser@example.com")
+    notification = Notification(
+        user_id=api_user.id,
+        message="Test message from test engine",
+        title="Test Title",
+        sender="Test Sender",
+    )
+    db_session.add(notification)
+    await db_session.commit()
+
+    # 7. Verify this notification is visible via API (proving shared database)
+    response = test_client.get("/notifications/apiuser@example.com")
+    assert response.status_code == HTTP_200_OK
+    notifications = response.json()
+    assert len(notifications) == 1
+    assert notifications[0]["message"] == "Test message from test engine"
+    assert notifications[0]["title"] == "Test Title"
+    assert notifications[0]["sender"] == "Test Sender"


### PR DESCRIPTION
Fixes #50

For reference, this deals with a [bug in litestar's `AsyncSession`](https://github.com/litestar-org/litestar/issues/1920#issuecomment-2592572498). We might want to readdress that at some point...

This is most probably needed before working on #37 which, according to my initial experiments, needs the `WebPushSubscription` to be stored in a `JSONB` field instead of a `JSON` to allow for comparison when selecting for identical subscriptions.

And `JSONB` isn't properly implemented in sqlite, and not in a compatible way.