### PR TITLE
DO NOT MERGE manage FranceConnect's `sector_identifier_url`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,9 @@ page](https://espace.partenaires.franceconnect.gouv.fr) (or
 ask us to do it) to add the redirect url for your PR, eg
 `https://ami-back-staging-prXX.osc-fr1.scalingo.io/ami-fs-test-login-callback`
 (Replace `XX` with your PR number)
+
+<img width="899" height="682" alt="Capture d’écran 2025-08-27 à 16 34 50" src="https://github.com/user-attachments/assets/5a569cb4-791b-4c84-8a1f-013622c8e81d" />
+
 - update [the PR](https://github.com/numerique-gouv/ami-notifications-api/pull/90)
 that manages the content of the
 [sector_identifier_url](https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,22 +202,31 @@ ask us to do it) to add the redirect url for your PR, eg
 
 <img width="899" height="682" alt="Capture d’écran 2025-08-27 à 16 34 50" src="https://github.com/user-attachments/assets/5a569cb4-791b-4c84-8a1f-013622c8e81d" />
 
-- update [the PR](https://github.com/numerique-gouv/ami-notifications-api/pull/90)
-that manages the content of the
-[sector_identifier_url](https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/)
-to add your PR's redirect url to the list of already authorized ones in
-[app/__init__.py:get_sector_identifier_url](https://github.com/numerique-gouv/ami-notifications-api/blob/DO-NOT-MERGE-sector_identifier_url-manager/app/__init__.py#L287-L291)
-, eg:
+- update the `PUBLIC_SECTOR_IDENTIFIER_URL` env variable in Scalingo
+that will be used by the
+[https://ami-back-staging.osc-fr1.scalingo.io/sector_identifier_url](https://ami-back-staging.osc-fr1.scalingo.io/sector_identifier_url)
+endpoint to serve the 
+[sector_identifier_url](https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/):
+Add your PR's redirect url to the list of already authorized ones
+[in scalingo](https://dashboard.scalingo.com/apps/osc-fr1/ami-back-staging/environment)
+eg:
 
 ```diff
-@get(path="/sector_identifier_url", include_in_schema=False)
-async def get_sector_identifier_url() -> Response[Any]:
-    redirect_uris: list[str] = [
-        "https://ami-back-staging.osc-fr1.scalingo.io/ami-fs-test-login-callback",
-+       "https://ami-back-staging-prXX.osc-fr1.scalingo.io/ami-fs-test-login-callback", # Replace `XX` with your PR number
-        "https://localhost:5173/ami-fs-test-login-callback",
-    ]
+PUBLIC_SECTOR_IDENTIFIER_URL="""
+  https://ami-back-staging.osc-fr1.scalingo.io/login-callback
+  https://ami-back-staging.osc-fr1.scalingo.io/rvo/login-callback
++ https://ami-back-staging-prXX.osc-fr1.scalingo.io/login-callback
++ https://ami-back-staging-prXX.osc-fr1.scalingo.io/rvo/login-callback
+  https://localhost:5173/login-callback
+  https://localhost:8000/rvo/login-callback
 ```
 
-# TODO: il y a 2 FCxion différentes. 1 pour un fake SP et un pour AMI
-# + MAJ § FC
+We now have two different FranceConnect buttons:
+- AMI as a service provider
+- RVO (Rendez-Vous Officiel) as a fake service provider
+
+You will thus need to add the two login redirect URLs, one for each, as shown above.
+
+Once the env variable is updated, make sure to
+[restart the web container](https://dashboard.scalingo.com/apps/osc-fr1/ami-back-staging/resources)
+so it's taken into account.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -284,6 +284,7 @@ async def get_sector_identifier_url() -> Response[Any]:
     redirect_uris: list[str] = [
         "https://ami-back-staging.osc-fr1.scalingo.io/ami-fs-test-login-callback",
         "https://ami-back-staging-pr90.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://ami-back-staging-pr91.osc-fr1.scalingo.io/ami-fs-test-login-callback",
         "https://localhost:5173/ami-fs-test-login-callback",
     ]
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -85,6 +85,7 @@ PUBLIC_FC_USERINFO_ENDPOINT = os.getenv("PUBLIC_FC_USERINFO_ENDPOINT", "")
 PUBLIC_FC_LOGOUT_ENDPOINT = os.getenv("PUBLIC_FC_LOGOUT_ENDPOINT", "")
 PUBLIC_API_URL = os.getenv("PUBLIC_API_URL", "")
 PUBLIC_APP_URL = os.getenv("PUBLIC_APP_URL", "")
+PUBLIC_SECTOR_IDENTIFIER_URL = os.getenv("PUBLIC_SECTOR_IDENTIFIER_URL", "")
 
 #### ENDPOINTS
 
@@ -282,21 +283,8 @@ async def get_fc_userinfo(
 @get(path="/sector_identifier_url", include_in_schema=False)
 async def get_sector_identifier_url() -> Response[Any]:
     redirect_uris: list[str] = [
-        "https://ami-back-staging.osc-fr1.scalingo.io/ami-fs-test-login-callback",
-        "https://ami-back-staging.osc-fr1.scalingo.io/login-callback",
-        "https://ami-back-staging-pr90.osc-fr1.scalingo.io/ami-fs-test-login-callback",
-        "https://ami-back-staging-pr90.osc-fr1.scalingo.io/login-callback",
-        "https://ami-back-staging-pr91.osc-fr1.scalingo.io/ami-fs-test-login-callback",
-        "https://ami-back-staging-pr91.osc-fr1.scalingo.io/login-callback",
-        "https://ami-back-staging-pr121.osc-fr1.scalingo.io/rvo/login-callback",
-        "https://ami-back-staging-pr121.osc-fr1.scalingo.io/login-callback",
-        "https://localhost:5173/ami-fs-test-login-callback",
-        "https://localhost:5173/login-callback",
-        "https://localhost:8000/login-callback",  # This is needed to test FC on a statically typed SPA (with `make build-app`).
-        "https://localhost:8000/rvo/login-callback",
-        "https://ami-back-staging.osc-fr1.scalingo.io/rvo/login-callback",
+        url.strip() for url in PUBLIC_SECTOR_IDENTIFIER_URL.strip().split("\n")
     ]
-
     return Response(redirect_uris)
 
 
@@ -342,6 +330,7 @@ def create_app(
             admin,
             login_callback,
             get_fc_userinfo,
+            get_sector_identifier_url,
             create_static_files_router(
                 path="/admin/static",
                 directories=[HTML_DIR_ADMIN],

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -292,6 +292,7 @@ async def get_sector_identifier_url() -> Response[Any]:
         "https://localhost:5173/login-callback",
         "https://localhost:8000/login-callback",  # This is needed to test FC on a statically typed SPA (with `make build-app`).
         "https://localhost:8000/rvo/login-callback",
+        "https://ami-back-staging.osc-fr1.scalingo.io/rvo/login-callback",
     ]
 
     return Response(redirect_uris)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -283,9 +283,15 @@ async def get_fc_userinfo(
 async def get_sector_identifier_url() -> Response[Any]:
     redirect_uris: list[str] = [
         "https://ami-back-staging.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://ami-back-staging.osc-fr1.scalingo.io/login-callback",
         "https://ami-back-staging-pr90.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://ami-back-staging-pr90.osc-fr1.scalingo.io/login-callback",
         "https://ami-back-staging-pr91.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://ami-back-staging-pr91.osc-fr1.scalingo.io/login-callback",
         "https://localhost:5173/ami-fs-test-login-callback",
+        "https://localhost:5173/login-callback",
+        "https://localhost:8000/login-callback",  # This is needed to test FC on a statically typed SPA (with `make build-app`).
+        "https://localhost:8000/rvo/login-callback",
     ]
 
     return Response(redirect_uris)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -279,6 +279,17 @@ async def get_fc_userinfo(
     return Response(response.content, status_code=response.status_code)
 
 
+@get(path="/sector_identifier_url", include_in_schema=False)
+async def get_sector_identifier_url() -> Response[Any]:
+    redirect_uris: list[str] = [
+        "https://ami-back-staging.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://ami-back-staging-pr90.osc-fr1.scalingo.io/ami-fs-test-login-callback",
+        "https://localhost:5173/ami-fs-test-login-callback",
+    ]
+
+    return Response(redirect_uris)
+
+
 def error_from_response(response: Response[str], ami_details: str | None = None) -> Response[str]:
     details = response.json()  # type: ignore[reportUnknownVariableType]
     if ami_details is not None:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -288,6 +288,8 @@ async def get_sector_identifier_url() -> Response[Any]:
         "https://ami-back-staging-pr90.osc-fr1.scalingo.io/login-callback",
         "https://ami-back-staging-pr91.osc-fr1.scalingo.io/ami-fs-test-login-callback",
         "https://ami-back-staging-pr91.osc-fr1.scalingo.io/login-callback",
+        "https://ami-back-staging-pr121.osc-fr1.scalingo.io/rvo/login-callback",
+        "https://ami-back-staging-pr121.osc-fr1.scalingo.io/login-callback",
         "https://localhost:5173/ami-fs-test-login-callback",
         "https://localhost:5173/login-callback",
         "https://localhost:8000/login-callback",  # This is needed to test FC on a statically typed SPA (with `make build-app`).

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -435,3 +435,12 @@ async def test_rvo_logout_callback(
     # As the user was properly logged out from FC, the local session is now emptied, and the user redirected to the fake service provider.
     assert response.headers["location"] == "/rvo/logged_out"
     assert test_client.get_session_data() == {}
+
+
+async def test_get_sector_identifier_url(
+    test_client: TestClient[Litestar],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.PUBLIC_SECTOR_IDENTIFIER_URL", "  https://example.com  \nfoobar \n")
+    response = test_client.get("/sector_identifier_url")
+    assert response.json() == ["https://example.com", "foobar"]


### PR DESCRIPTION
Check the [CONTRIBUTING.md](https://github.com/numerique-gouv/ami-notifications-api/blob/DO-NOT-MERGE-sector_identifier_url-manager/CONTRIBUTING.md) file for more explanation on how to give FC access to PRs deployed as review apps on Scalingo