### PR TITLE
Set a default (fake) FranceConnect client secret

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,7 +7,7 @@ PUBLIC_API_URL="https://localhost:5173"
 
 #### France Connect client id and client secret for the Service Provider
 PUBLIC_FC_SERVICE_PROVIDER_CLIENT_ID="88d6fc32244b89e2617388fb111e668fec7b7383c841a08eefbd58fd11637eec"
-FC_SERVICE_PROVIDER_CLIENT_SECRET=""
+FC_SERVICE_PROVIDER_CLIENT_SECRET="fake secret"
 PUBLIC_FC_BASE_URL="https://fcp-low.sbx.dev-franceconnect.fr"
 PUBLIC_FC_SERVICE_PROVIDER_REDIRECT_URL="https://localhost:5173/ami-fs-test-login-callback"
 PUBLIC_FC_AUTHORIZATION_ENDPOINT="/api/v2/authorize"


### PR DESCRIPTION
This way tests should run locally and on the CI