### PR TITLE
Don't fail when notifying a user that has a revoked registration (replaces #165)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -150,7 +150,11 @@ async def notify(
         response = httpx.post(
             registration.subscription["endpoint"], content=message.encrypted, headers=headers
         )
-        response.raise_for_status()
+        if response.status_code < 500:
+            # For example we could have "410: gone" if the registration has been revoked.
+            continue
+        else:
+            response.raise_for_status()
     notification = await create_notification(data, db_session)
     return Response(notification, status_code=HTTP_201_CREATED)
 


### PR DESCRIPTION
I've merged #165 in the wrong branch by accident. This is an attempt at re-merging it, on `main` this time around 😬 