### PR TITLE
Increase the httpx default timeout to 60seconds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,15 @@ repos:
     # Run the formatter.
     - id: ruff-format
 
+# Make sure no code is using httpx straight out of the box instead of our own configured one.
+- repo: local
+  hooks:
+    - id: no-vanilla-httpx-usage
+      name: no vanilla httpx usage
+      entry: bin/check-no-vanilla-httpx-usage.sh
+      language: system
+      files: \.py$
+
 # JavaScript/TypeScript linting and formatting
 - repo: local
   hooks:
@@ -17,7 +26,6 @@ repos:
       entry: npm run lint-and-format
       language: system
       files: \.(js|ts|svelte|json)$
-      require_serial: true
 
 # HTML linting and formatting
 - repo: https://github.com/rtts/djhtml
@@ -34,4 +42,3 @@ repos:
       entry: uv run pyright
       language: system
       files: \.py$
-      require_serial: true

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
-import httpx
 import jwt
 import sentry_sdk
 from litestar import (
@@ -35,6 +34,7 @@ from app.controllers.notification import NotificationController
 from app.controllers.registration import RegistrationController
 from app.controllers.user import UserController
 from app.database import alchemy
+from app.httpx import httpx
 
 from .ami_admin import ami_admin_router
 from .rvo import rvo_router

--- a/app/ami_admin.py
+++ b/app/ami_admin.py
@@ -2,7 +2,6 @@ import os
 import uuid
 from typing import Annotated, Any
 
-import httpx
 import jwt
 from litestar import (
     Request,
@@ -23,6 +22,7 @@ from litestar.status_codes import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import ami_admin_auth
+from app.httpx import httpx
 from app.models import Notification, User
 from app.services.notification import NotificationService
 from app.services.user import UserService

--- a/app/controllers/notification.py
+++ b/app/controllers/notification.py
@@ -3,7 +3,6 @@ import uuid
 from collections.abc import Sequence
 from typing import Annotated, Any, cast
 
-import httpx
 from advanced_alchemy.extensions.litestar import providers
 from litestar import Controller, WebSocket, get, patch, post, websocket
 from litestar.channels import ChannelsPlugin
@@ -13,6 +12,7 @@ from pydantic import TypeAdapter
 from webpush import WebPush, WebPushSubscription
 
 from app import env, models, schemas
+from app.httpx import httpx
 from app.services.notification import NotificationService
 from app.services.user import UserService
 

--- a/app/controllers/user.py
+++ b/app/controllers/user.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-import httpx
 import jwt
 from advanced_alchemy.extensions.litestar import providers
 from litestar import Controller, Request, Response, get
 
 from app import env, models, schemas
+from app.httpx import httpx
 from app.services.user import UserService
 
 

--- a/app/httpx.py
+++ b/app/httpx.py
@@ -1,0 +1,5 @@
+"""Setup any system wide httpx configuration here."""
+
+import httpx as do_not_use_httpx
+
+httpx = do_not_use_httpx.Client(timeout=60)

--- a/app/rvo.py
+++ b/app/rvo.py
@@ -2,7 +2,6 @@ import os
 import uuid
 from typing import Any
 
-import httpx
 import jwt
 from litestar import (
     Request,
@@ -22,7 +21,7 @@ from litestar.status_codes import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import env, rvo_auth
+from app import env, httpx, rvo_auth
 from app.models import Notification, User
 from app.services.notification import NotificationService
 from app.services.user import UserService

--- a/bin/check-no-vanilla-httpx-usage.sh
+++ b/bin/check-no-vanilla-httpx-usage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for file in $@; do
+  if grep --exclude=app/httpx.py -r "\(^\s*import httpx\)\|\(^\s*from httpx import\)" $file ; then
+    exit 1
+  fi
+done || exit $?
+


### PR DESCRIPTION
Fixes #195

This PR increases the default timeout for all httpx queries to one minute, and adds a pre-commit hook to force the usage of our own configured httpx client to make sure those defaults timeouts are used everywhere.