### PR TITLE
Auto provision the PUBLIC_PRO_CONNECT_AMI_ADMIN_REDIRECT_URL env var on Scalingo

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -13,6 +13,10 @@
     "PUBLIC_FC_SERVICE_PROVIDER_REDIRECT_URL": {
       "generator": "url",
       "template": "%URL%/rvo/login-callback"
+    },
+    "PUBLIC_PRO_CONNECT_AMI_ADMIN_REDIRECT_URL": {
+      "generator": "url",
+      "template": "%URL%/ami_admin/login-callback"
     }
   }
 }


### PR DESCRIPTION
This is following #173 : auto provision the env var so any new review app will have its redirect URL properly set up.