### PR TITLE
AMI, RVO: properly pass the STATE to FC even when not using a proxy

### DIFF
--- a/tests/ami/test_basic.py
+++ b/tests/ami/test_basic.py
@@ -641,7 +641,7 @@ async def test_login_callback(
 
     test_client.set_session_data({"nonce": NONCE, "state": STATE})
     response = test_client.get(
-        f"/login-callback?code=fake-code&fc_state={STATE}", follow_redirects=False
+        f"/login-callback?code=fake-code&state={STATE}", follow_redirects=False
     )
 
     assert response.status_code == 302
@@ -690,7 +690,7 @@ async def test_login_callback_bad_nonce(
     STATE = "some random state"
     test_client.set_session_data({"nonce": "some other nonce", "state": STATE})
     response = test_client.get(
-        f"/login-callback?code=fake-code&fc_state={STATE}", follow_redirects=False
+        f"/login-callback?code=fake-code&state={STATE}", follow_redirects=False
     )
 
     assert response.status_code == 302
@@ -710,7 +710,7 @@ async def test_login_callback_bad_state(
     STATE = "some random state"
     test_client.set_session_data({"nonce": "some other nonce", "state": "some other state"})
     response = test_client.get(
-        f"/login-callback?code=fake-code&fc_state={STATE}", follow_redirects=False
+        f"/login-callback?code=fake-code&state={STATE}", follow_redirects=False
     )
 
     assert response.status_code == 302

--- a/tests/rvo/test_basic.py
+++ b/tests/rvo/test_basic.py
@@ -84,7 +84,7 @@ async def test_rvo_login_callback(
     )
 
     test_client.set_session_data({"nonce": NONCE, "state": STATE})
-    response = test_client.get(f"/rvo/login-callback?code=fake-code&fc_state={STATE}")
+    response = test_client.get(f"/rvo/login-callback?code=fake-code&state={STATE}")
 
     assert response.status_code == 200
     assert "error" not in str(response.url)
@@ -125,7 +125,7 @@ async def test_rvo_login_callback_bad_nonce(
 
     STATE = "some random state"
     test_client.set_session_data({"nonce": "some other nonce", "state": STATE})
-    response = test_client.get(f"/rvo/login-callback?code=fake-code&fc_state={STATE}")
+    response = test_client.get(f"/rvo/login-callback?code=fake-code&state={STATE}")
 
     assert response.status_code == 200
     assert (
@@ -140,7 +140,7 @@ async def test_login_callback_bad_state(
     STATE = "some random state"
     test_client.set_session_data({"nonce": "some other nonce", "state": "some other state"})
     response = test_client.get(
-        f"/rvo/login-callback?code=fake-code&fc_state={STATE}", follow_redirects=False
+        f"/rvo/login-callback?code=fake-code&state={STATE}", follow_redirects=False
     )
 
     assert response.status_code == 302


### PR DESCRIPTION
This is following #254 which was incomplete: it was working properly in my tests as we're using a FranceConnect proxy.

In this PR, the changes should fix that, and have the STATE properly passed around even when not using the FC proxy (in production).