### PR TITLE
[AMI] use notification creation date instead of send_date (#358)

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -45,7 +45,7 @@ class Notification(BaseModel):
     item_milestone_end_date: datetime.datetime | None
     item_external_url: str | None
 
-    send_date: datetime.datetime
+    created_at: datetime.datetime
 
     read: bool
 

--- a/public/mobile-app/src/lib/notifications.test.js
+++ b/public/mobile-app/src/lib/notifications.test.js
@@ -18,7 +18,7 @@ describe('/notifications', () => {
       // Given
       const notifications = [
         {
-          send_date: '2025-09-19T13:52:23.279545',
+          created_at: '2025-09-19T13:52:23.279545',
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',
@@ -27,7 +27,7 @@ describe('/notifications', () => {
           read: false,
         },
         {
-          send_date: '2025-09-19T12:59:04.950812',
+          created_at: '2025-09-19T12:59:04.950812',
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test',
           content_body: 'test',
@@ -53,7 +53,7 @@ describe('/notifications', () => {
       // Given
       const notifications = [
         {
-          send_date: '2025-09-19T13:52:23.279545',
+          created_at: '2025-09-19T13:52:23.279545',
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',
@@ -79,7 +79,7 @@ describe('/notifications', () => {
       // Given
       const read_notification = [
         {
-          send_date: '2025-09-19T13:52:23.279545',
+          created_at: '2025-09-19T13:52:23.279545',
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',

--- a/public/mobile-app/src/lib/notifications.ts
+++ b/public/mobile-app/src/lib/notifications.ts
@@ -10,7 +10,7 @@ export const PUBLIC_API_WS_URL = PUBLIC_API_URL.replace('https://', 'wss://').re
 
 export type Notification = {
   id: string
-  send_date: Date
+  created_at: Date
   user_id: string
   content_title: string
   content_body: string

--- a/public/mobile-app/src/routes/notifications/+page.svelte
+++ b/public/mobile-app/src/routes/notifications/+page.svelte
@@ -57,7 +57,7 @@
             <a href="/" onclick={(event) => markNotificationAsRead(event, notification.id)} data-testid="notification-link-{notification.id}">{notification.content_title}</a>
           </h3>
           <span class="notification__age">
-            {prettyDate(notification.send_date)}
+            {prettyDate(notification.created_at)}
           </span>
         </div>
         <p class="fr-tile__desc">{notification.content_body}</p>

--- a/public/mobile-app/src/routes/notifications/page.svelte.test.ts
+++ b/public/mobile-app/src/routes/notifications/page.svelte.test.ts
@@ -40,7 +40,7 @@ describe('/+page.svelte', () => {
       .spyOn(notificationsMethods, 'retrieveNotifications')
       .mockImplementation(async () => [
         {
-          send_date: new Date('2025-09-19T13:52:23.279545'),
+          created_at: new Date('2025-09-19T13:52:23.279545'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',
@@ -49,7 +49,7 @@ describe('/+page.svelte', () => {
           read: false,
         },
         {
-          send_date: new Date('2025-09-19T12:59:04.950812'),
+          created_at: new Date('2025-09-19T12:59:04.950812'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test',
           content_body: 'test',
@@ -82,7 +82,7 @@ describe('/+page.svelte', () => {
       .spyOn(notificationsMethods, 'retrieveNotifications')
       .mockImplementationOnce(async () => [
         {
-          send_date: new Date('2025-09-19T13:52:23.279545'),
+          created_at: new Date('2025-09-19T13:52:23.279545'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',
@@ -91,7 +91,7 @@ describe('/+page.svelte', () => {
           read: false,
         },
         {
-          send_date: new Date('2025-09-19T12:59:04.950812'),
+          created_at: new Date('2025-09-19T12:59:04.950812'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test',
           content_body: 'test',
@@ -102,7 +102,7 @@ describe('/+page.svelte', () => {
       ])
       .mockImplementationOnce(async () => [
         {
-          send_date: new Date('2025-09-19T13:52:23.279545'),
+          created_at: new Date('2025-09-19T13:52:23.279545'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',
@@ -111,7 +111,7 @@ describe('/+page.svelte', () => {
           read: true,
         },
         {
-          send_date: new Date('2025-09-19T12:59:04.950812'),
+          created_at: new Date('2025-09-19T12:59:04.950812'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test',
           content_body: 'test',
@@ -124,7 +124,7 @@ describe('/+page.svelte', () => {
       .spyOn(notificationsMethods, 'readNotification')
       .mockImplementation(async () => {
         return {
-          send_date: new Date('2025-09-19T13:52:23.279545'),
+          created_at: new Date('2025-09-19T13:52:23.279545'),
           user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
           sender: 'test 2',
           content_body: 'test 2',

--- a/tests/ami/test_notification.py
+++ b/tests/ami/test_notification.py
@@ -459,7 +459,7 @@ async def test_get_notifications(
         "item_milestone_start_date": None,
         "item_milestone_end_date": None,
         "item_external_url": None,
-        "send_date": notification.send_date.isoformat().replace("+00:00", "Z"),
+        "created_at": notification.created_at.isoformat().replace("+00:00", "Z"),
         "read": False,
     }
 
@@ -628,7 +628,7 @@ async def test_read_notification(
         "item_milestone_start_date": None,
         "item_milestone_end_date": None,
         "item_external_url": None,
-        "send_date": notification.send_date.isoformat().replace("+00:00", "Z"),
+        "created_at": notification.created_at.isoformat().replace("+00:00", "Z"),
         "read": True,
     }
 


### PR DESCRIPTION
fixes #358 