### PR TITLE
Redirect on click on notification if link exists (#484)

### DIFF
--- a/public/mobile-app/src/lib/notifications.test.js
+++ b/public/mobile-app/src/lib/notifications.test.js
@@ -34,6 +34,7 @@ describe('/notifications', () => {
           id: 'f62c66b2-7bd5-4696-883-2d40c08a1',
           content_title: 'test 2',
           read: false,
+          item_external_url: '',
         },
         {
           created_at: '2025-09-19T12:59:04.950812',
@@ -43,6 +44,7 @@ describe('/notifications', () => {
           id: '2689c3b3-e95c-4d73-b37d-55f430688af9',
           content_title: 'test',
           read: true,
+          item_external_url: '',
         },
       ]
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -69,6 +71,7 @@ describe('/notifications', () => {
           id: 'f62c66b2-7bd5-4696-883-2d40c08a1',
           content_title: 'test 2',
           read: false,
+          item_external_url: '',
         },
       ]
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -95,6 +98,7 @@ describe('/notifications', () => {
           id: 'f62c66b2-7bd5-4696-883-2d40c08a1',
           content_title: 'test 2',
           read: true,
+          item_external_url: '',
         },
       ]
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/public/mobile-app/src/lib/notifications.ts
+++ b/public/mobile-app/src/lib/notifications.ts
@@ -16,6 +16,7 @@ export type AppNotification = {
   content_body: string
   content_icon?: string
   sender: string
+  item_external_url: string
   read: boolean
 }
 

--- a/public/mobile-app/src/routes/notifications/+page.svelte
+++ b/public/mobile-app/src/routes/notifications/+page.svelte
@@ -23,9 +23,20 @@
     })
   })
 
-  const markNotificationAsRead = async (event: MouseEvent, notificationId: string) => {
+  const redirectToLink = (notificationItemExternalUrl: string) => {
+    if (notificationItemExternalUrl) {
+      window.location.href = notificationItemExternalUrl
+    }
+  }
+
+  const clickOnNotification = async (
+    event: MouseEvent,
+    notificationId: string,
+    notificationItemExternalUrl: string
+  ) => {
     event.preventDefault()
-    let result = await readNotification(notificationId)
+    await readNotification(notificationId)
+    redirectToLink(notificationItemExternalUrl)
   }
 
   const navigateToPreviousPage = async () => {
@@ -87,7 +98,7 @@
             <h3 class="fr-tile__title">
               <a
                 href="/"
-                onclick={(event) => markNotificationAsRead(event, notification.id)}
+                onclick={(event) => clickOnNotification(event, notification.id, notification.item_external_url)}
                 data-testid="notification-link-{notification.id}"
                 >{notification.content_title}</a
               >

--- a/public/mobile-app/src/routes/notifications/page.svelte.test.ts
+++ b/public/mobile-app/src/routes/notifications/page.svelte.test.ts
@@ -80,6 +80,7 @@ describe('/+page.svelte', () => {
           id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
           content_title: 'test 2',
           read: false,
+          item_external_url: '',
         },
         {
           created_at: new Date('2025-09-19T12:59:04.950812'),
@@ -90,6 +91,7 @@ describe('/+page.svelte', () => {
           content_title: 'test',
           content_icon: 'some-icon',
           read: true,
+          item_external_url: '',
         },
       ])
 
@@ -129,6 +131,7 @@ describe('/+page.svelte', () => {
           id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
           content_title: 'test 2',
           read: false,
+          item_external_url: '',
         },
         {
           created_at: new Date('2025-09-19T12:59:04.950812'),
@@ -138,6 +141,7 @@ describe('/+page.svelte', () => {
           id: '2689c3b3-e95c-4d73-b37d-55f430688af9',
           content_title: 'test',
           read: true,
+          item_external_url: '',
         },
       ])
       .mockImplementationOnce(async () => [
@@ -149,6 +153,7 @@ describe('/+page.svelte', () => {
           id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
           content_title: 'test 2',
           read: true,
+          item_external_url: '',
         },
         {
           created_at: new Date('2025-09-19T12:59:04.950812'),
@@ -158,6 +163,7 @@ describe('/+page.svelte', () => {
           id: '2689c3b3-e95c-4d73-b37d-55f430688af9',
           content_title: 'test',
           read: true,
+          item_external_url: '',
         },
       ])
     const spy2 = vi
@@ -171,6 +177,7 @@ describe('/+page.svelte', () => {
           id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
           content_title: 'test 2',
           read: true,
+          item_external_url: '',
         }
       })
 
@@ -197,5 +204,67 @@ describe('/+page.svelte', () => {
       'notification-2689c3b3-e95c-4d73-b37d-55f430688af9'
     )
     expect(notification2).toHaveClass('read')
+  })
+
+  test('should redirect to item_external_url when is set and user clicks on notification', async () => {
+    // Given
+    vi.spyOn(notificationsMethods, 'retrieveNotifications').mockImplementationOnce(
+      async () => [
+        {
+          created_at: new Date('2025-09-19T13:52:23.279545'),
+          user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
+          sender: 'test 2',
+          content_body: 'test 2',
+          id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
+          content_title: 'test 2',
+          read: false,
+          item_external_url: 'https://www.service-public.gouv.fr',
+        },
+      ]
+    )
+    vi.stubGlobal('location', { href: 'fake-link' })
+
+    render(Page)
+    const notificationLink = await waitFor(() =>
+      screen.getByTestId('notification-link-f62c66b2-7bd5-4696-8383-2d40c08a1')
+    )
+
+    // When
+    await notificationLink.click()
+    wss.send('ping')
+
+    // Then
+    expect(globalThis.window.location.href).toBe('https://www.service-public.gouv.fr')
+  })
+
+  test('should not redirect when item_external_url is not set and user clicks on notification', async () => {
+    // Given
+    vi.spyOn(notificationsMethods, 'retrieveNotifications').mockImplementationOnce(
+      async () => [
+        {
+          created_at: new Date('2025-09-19T13:52:23.279545'),
+          user_id: '3ac73f4f-4be2-456a-9c2e-ddff480d5767',
+          sender: 'test 2',
+          content_body: 'test 2',
+          id: 'f62c66b2-7bd5-4696-8383-2d40c08a1',
+          content_title: 'test 2',
+          read: false,
+          item_external_url: '',
+        },
+      ]
+    )
+    vi.stubGlobal('location', { href: 'fake-link' })
+
+    render(Page)
+    const notificationLink = await waitFor(() =>
+      screen.getByTestId('notification-link-f62c66b2-7bd5-4696-8383-2d40c08a1')
+    )
+
+    // When
+    await notificationLink.click()
+    wss.send('ping')
+
+    // Then
+    expect(globalThis.window.location.href).toBe('fake-link')
   })
 })


### PR DESCRIPTION
Closes #484 

Can be tested on the review app by sending a notification with the API endpoint: https://ami-back-staging-pr495.osc-fr1.scalingo.io/schema/rapidoc#post-/api/v1/notifications
Example:
{
  "recipient_fc_hash": "4abd71ec1f581dce2ea2221cbeac7c973c6aea7bcb835acdfe7d6494f1528060",
  "content_title": "Test title",
  "content_body": "Lorem ipsum",
  "content_icon": "foo",
  "item_type": "OTV",
  "item_id": "A-5-JGBJ5VMOY1",
  "item_status_label": "Brouillon",
  "item_generic_status": "new",
  "item_canal": "ami",
  "item_milestone_start_date": "2025-12-26T23:00:00.000Z",
  "item_milestone_end_date": "2026-01-02T23:00:00.000Z",
  "item_external_url": "https://www.service-public.gouv.fr/",
  "send_date": "2025-11-27T10:55:00.000Z",
  "try_push": true
}