### PR TITLE
Make sure the default icon is displayed when no icon is provided in NotificationIcon's props

### DIFF
--- a/public/mobile-app/src/lib/NotificationIcon.svelte
+++ b/public/mobile-app/src/lib/NotificationIcon.svelte
@@ -10,7 +10,7 @@
   let checkedIcon: string = $state('')
 
   onMount(async () => {
-    checkedIcon = dsfrIconList.filter((i) => i.name === icon.replace('fr-icon-', ''))
+    checkedIcon = dsfrIconList.filter((i) => i.name === icon?.replace('fr-icon-', ''))
       .length
       ? icon
       : defaultIcon


### PR DESCRIPTION
Fixes #551 

Not sure why tests where passing without any issue, but in the browser it would raise an exception, and the default icon would not be displayed at all.