### PR TITLE
Send only a DATA push notification to mobile apps (#648)

### DIFF
--- a/ami/notification/push.py
+++ b/ami/notification/push.py
@@ -70,21 +70,18 @@ async def push(notification: Notification, try_push: bool) -> None:
                 except Exception as e:
                     logger.exception(f"Failed to send notification: {e}")
         else:
+            # We need to make absolutely sure that there are no values that are not strings,
+            # or the Firebase admin SDK will fail.
+            data = {
+                k: str(v)
+                for k, v in notification_data.model_dump(mode="json", exclude_none=True).items()
+            }
             message = messaging.Message(
-                # Send both a Notification (displayed automatically by the operating system)
-                # even if the app is in the background...
-                notification=messaging.Notification(
-                    title=notification_data.title,
-                    body=notification_data.message,
-                ),
+                # Send a "data message" (not a Notification, that would be automatically managed by Firebase)
+                # cf https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type
                 # ... and a full data dump, so the app can display more information if needed
                 # once the application is displayed.
-                # We need to make absolutely sure that there are no values that are not strings,
-                # or the Firebase admin SDK will fail.
-                data={
-                    k: str(v)
-                    for k, v in notification_data.model_dump(mode="json", exclude_none=True).items()
-                },
+                data={**data, "title": notification_data.title, "body": notification_data.message},
                 token=registration.typed_subscription.fcm_token,
             )
             try:

--- a/ami/notification/tests/api/test_partner_notifications.py
+++ b/ami/notification/tests/api/test_partner_notifications.py
@@ -150,8 +150,8 @@ def test_create_mobile_notification(
     send_mock.assert_called_once()
     call_args = send_mock.call_args
     message = call_args[0][0]  # First positional argument
-    assert message.notification.title == "Brouillon de nouvelle demande de démarche d'OTV"
-    assert message.notification.body == "Merci d'avoir initié votre demande"
+    assert message.data["title"] == "Brouillon de nouvelle demande de démarche d'OTV"
+    assert message.data["body"] == "Merci d'avoir initié votre demande"
     assert message.token == mobile_registration.subscription["fcm_token"]
 
 


### PR DESCRIPTION
Fixes #648

DO NOT MERGE until the mobile applications are ready to be released, or the notifications won't properly display.