### PR TITLE
Don't navigate to promoted pages (#570)

### DIFF
--- a/public/mobile-app/src/app.d.ts
+++ b/public/mobile-app/src/app.d.ts
@@ -11,6 +11,7 @@ declare global {
   interface Window {
     _paq?: any[];
     NativeBridge?: any;
+    NativeURLs?: string[];
   }
 }
 

--- a/public/mobile-app/src/lib/notifications.ts
+++ b/public/mobile-app/src/lib/notifications.ts
@@ -38,7 +38,7 @@ export const fetchAndStoreNotifications = async () => {
 };
 
 export const getNotificationsFromStore = async (): Promise<AppNotification[]> => {
-  const notificationsString: string = localStorage.getItem('notifications') || '';
+  const notificationsString: string = localStorage.getItem('notifications') || '[]';
   return JSON.parse(notificationsString);
 };
 

--- a/public/mobile-app/src/routes/+layout.svelte
+++ b/public/mobile-app/src/routes/+layout.svelte
@@ -3,11 +3,12 @@
   import '@gouvfr/dsfr/dist/utility/utility.min.css';
   import '../app.css';
   import { onMount } from 'svelte';
-  import { afterNavigate, goto } from '$app/navigation';
+  import { afterNavigate, beforeNavigate, goto } from '$app/navigation';
   import { env } from '$env/dynamic/public';
   import Toasts from '$lib/components/Toasts.svelte';
   import { initDsfr } from '$lib/dsfr';
   import { initMatomo, trackPageView } from '$lib/matomo';
+  import { emit } from '$lib/nativeEvents';
 
   let { children } = $props();
 
@@ -19,6 +20,21 @@
     await initDsfr();
 
     initMatomo();
+  });
+
+  beforeNavigate((navigation) => {
+    const url = navigation.to?.url;
+    if (!url) {
+      return;
+    }
+    emit('navigateTo', url);
+    const path = url.href.replace(url.origin, ''); // Remove the `https://xxxx.yyy:zzzz` part of the current url, keep eg `/#/settings`.
+    if (window.NativeURLs?.includes(path)) {
+      console.log(
+        `Cancel navigation to ${url}, found an entry in the window.NativeURLs, let the mobile app handle it`
+      );
+      navigation.cancel();
+    }
   });
 
   afterNavigate(() => {

--- a/public/mobile-app/src/routes/layout.svelte.test.ts
+++ b/public/mobile-app/src/routes/layout.svelte.test.ts
@@ -24,6 +24,7 @@ describe('+layout.svelte', () => {
   afterEach(() => {
     vi.resetAllMocks();
     delete window.NativeBridge;
+    delete window.NativeURLs;
   });
 
   describe('whitelisting', () => {
@@ -74,6 +75,50 @@ describe('+layout.svelte', () => {
       await waitFor(() => {
         expect(spy).not.toHaveBeenCalledWith('/#/forbidden');
       });
+    });
+  });
+
+  describe('cancelling navigation to pages promoted in mobile apps', () => {
+    test('should cancel navigation if the URL is in window.NativeURLs', () => {
+      // Given
+      let beforeNavigateCallback: (navigation: any) => void;
+      vi.spyOn(navigationMethods, 'beforeNavigate').mockImplementation((cb) => {
+        beforeNavigateCallback = cb;
+      });
+      window.NativeURLs = ['/#/settings'];
+      render(Layout, { children: (() => {}) as any });
+
+      const cancel = vi.fn();
+
+      // When
+      beforeNavigateCallback!({
+        to: { url: new URL('https://localhost:5173/#/settings') },
+        cancel,
+      });
+
+      // Then
+      expect(cancel).toHaveBeenCalled();
+    });
+
+    test('should not cancel navigation if the URL is not in window.NativeURLs', () => {
+      // Given
+      let beforeNavigateCallback: (navigation: any) => void;
+      vi.spyOn(navigationMethods, 'beforeNavigate').mockImplementation((cb) => {
+        beforeNavigateCallback = cb;
+      });
+      window.NativeURLs = ['/#/settings'];
+      render(Layout, { children: (() => {}) as any });
+
+      const cancel = vi.fn();
+
+      // When
+      beforeNavigateCallback!({
+        to: { url: new URL('https://localhost:5173/#/other') },
+        cancel,
+      });
+
+      // Then
+      expect(cancel).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Fixes #570, fixes #547

À utiliser dans les applications natives lorsqu'elles démarrent : elle peuvent renseigner la liste des URLs de pages promues (par exemple `/#/settings`) dans l'objet `window.NativeURLs`.

À chaque tentative de navigation de la webapp, il y a un événement `navigateTo` avec l'url complète qui est envoyé aux applications natives, et si l'url qui doit être chargée par la webapp contient un fragment qui est listé dans `window.NativeURLs`, alors la navigation ne se fait pas du tout.

Cela devrait éviter les flashs de navigation quand l'application web affiche brièvement la page avant que l'application native détecte que l'url chargée est en fait pour une page promue, et affiche ensuite la page promue en lieu et place de la webview.