### PR TITLE
Center the FranceConnect button vertically (#515)

### DIFF
--- a/public/mobile-app/src/routes/+page.svelte
+++ b/public/mobile-app/src/routes/+page.svelte
@@ -200,11 +200,11 @@
           margin-bottom: 1rem;
         }
 
-        .france-connect-text {
-          margin-bottom: 40px;
-        }
-
         .fr-connect-group {
+          display: flex;
+          flex-direction: column;
+          flex-grow: 1;
+          justify-content: center;
           text-align: center;
         }
       }


### PR DESCRIPTION
Fixes #515 

Voici ce à quoi ça ressemble :


https://github.com/user-attachments/assets/2e120b0e-7baa-4af5-85ef-4e40bda76af1

