### PR TITLE
No FC proxy in production

### DIFF
--- a/.env
+++ b/.env
@@ -14,9 +14,6 @@ PUBLIC_MATOMO_URL="https://stats.data.gouv.fr/"
 PUBLIC_MATOMO_CDN_URL="https://stats.data.gouv.fr/"
 PUBLIC_MATOMO_SITE_ID="315"
 
-#### FranceConnect login proxy. This should be empty in production.
-PUBLIC_FC_PROXY="https://ami-fc-proxy-dev.osc-fr1.scalingo.io/"
-
 #### FranceConnect AMI variables
 FC_AMI_CLIENT_ID="33fe498cc172fe691778912a2967baa650b24f1ae0ebbe47ae552f37b2d25ead"
 FC_AMI_CLIENT_SECRET="fake secret for AMI"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,13 @@ jobs:
         working-directory: ./public/mobile-app
         run: npm ci
 
-      - run: make lint-and-format
+      - name: lint-and-format
+        env:
+          AUTH_COOKIE_JWT_SECRET: secret
+          PARTNERS_PSL_SECRET: secret
+          PUBLIC_WEBSITE_PUBLIC: true
+          PUBLIC_FC_PROXY: https://ami-fc-proxy-dev.osc-fr1.scalingo.io/
+        run: make lint-and-format
 
   run-tests:
     name: python
@@ -66,6 +72,8 @@ jobs:
           echo "PARTNERS_DINUM_AMI_SECRET=\"secret\"" >> .env.local
 
       - name: Run tests
+        env:
+          PUBLIC_FC_PROXY: https://ami-fc-proxy-dev.osc-fr1.scalingo.io/
         run: make test-ci
 
   mobile-app-tests:
@@ -95,4 +103,5 @@ jobs:
           AUTH_COOKIE_JWT_SECRET: secret
           PARTNERS_PSL_SECRET: secret
           PUBLIC_WEBSITE_PUBLIC: true
+          PUBLIC_FC_PROXY: https://ami-fc-proxy-dev.osc-fr1.scalingo.io/
         run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,8 @@ from the following files in your environment directory, in this order:
 
     .env # loaded in all cases
     .env.local # loaded in all cases, ignored by git
-    .env.development # loaded only in development
+    .env.development # loaded only in development, values should be overloaded on Scalingo
     .env.development.local # loaded only in development, ignored by git
-
-`.env.development` files are not loaded by the backend unless you add them to your `uv run` command lines.
 
 ### 4. Run Database Migrations
 
@@ -249,8 +247,13 @@ on Scalingo.
 
 We now use a
 [proxy](https://ami-fc-proxy-dev.osc-fr1.scalingo.io/)
-through the configuration of the `FC_PROXY` env variable in the `.env` file, so
-none of that is needed anymore, it's all been configured once and for all.
+through the configuration of the `FC_PROXY` env variable.
+It needs to be set through Scalingo in the staging and review apps,
+and for local development, it needs to be set in the `.env.local` file.
+
+```
+PUBLIC_FC_PROXY="https://ami-fc-proxy-dev.osc-fr1.scalingo.io/"
+```
 
 ## agent-admin space ("Espace Partenaire AMI")
 

--- a/ami/settings.py
+++ b/ami/settings.py
@@ -243,7 +243,12 @@ assert AUTH_COOKIE_JWT_SECRET, "set a random AUTH_COOKIE_JWT_SECRET in your .env
 FC_AMI_CLIENT_ID = CONFIG["FC_AMI_CLIENT_ID"]
 FC_AMI_CLIENT_SECRET = CONFIG["FC_AMI_CLIENT_SECRET"]
 PUBLIC_FC_BASE_URL = CONFIG["PUBLIC_FC_BASE_URL"]
-PUBLIC_FC_PROXY = CONFIG["PUBLIC_FC_PROXY"]
+
+# This should not be set in production:
+# It should be set in the .env.local file for local development
+# and in the Scalingo staging and review apps as an env variable.
+PUBLIC_FC_PROXY = CONFIG.get("PUBLIC_FC_PROXY")
+
 FC_SCOPE = CONFIG["FC_SCOPE"]
 FC_AMI_REDIRECT_URL = PUBLIC_API_URL + "/login-callback"
 FC_TOKEN_ENDPOINT = "/api/v2/token"


### PR DESCRIPTION
Fixes #826

La variable d'env `PUBLIC_FC_PROXY` qui est utilisée lors du build de l'app mobile n'est pas renseignée dans l'app scalingo `ami-back-prod`, mais elle est renseignée dans le fichier `.env` qui est chargé explicitement comme valeurs par défaut dans `settings.py`.

Ces variables d'env de `.env` peuvent ensuite être surchargées, entre autres par les variables d'environnement du système, mais dans le cas de `PUBLIC_FC_PROXY` la variable n'est pas définie, et donc ne surchage pas celle par défaut du `.env`.

Je n'ai pas trouvé de moyen de définir une variable d'env vide que ce soit par l'interface web de scalingo, leur API, ou la CLI.