### PR TITLE
Keep the (empty) PUBLIC_FC_PROXY env variable for the frontend

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,9 @@ PUBLIC_MATOMO_URL="https://stats.data.gouv.fr/"
 PUBLIC_MATOMO_CDN_URL="https://stats.data.gouv.fr/"
 PUBLIC_MATOMO_SITE_ID="315"
 
+#### FranceConnect login proxy. This should be empty in production.
+PUBLIC_FC_PROXY=""
+
 #### FranceConnect AMI variables
 FC_AMI_CLIENT_ID="33fe498cc172fe691778912a2967baa650b24f1ae0ebbe47ae552f37b2d25ead"
 FC_AMI_CLIENT_SECRET="fake secret for AMI"


### PR DESCRIPTION
Fixes #826 (again)