### PR TITLE
Track holiday zones on matomo (#750)

### DIFF
--- a/public/mobile-app/src/lib/ConnectedHomepage.svelte.test.ts
+++ b/public/mobile-app/src/lib/ConnectedHomepage.svelte.test.ts
@@ -38,6 +38,7 @@ describe('/ConnectedHomepage.svelte', () => {
         ...original,
         PUBLIC_API_URL: 'https://localhost:8000',
         PUBLIC_FEATUREFLAG_REQUESTS_ENABLED: 'true',
+        PUBLIC_MATOMO_ENABLED: 'false',
       });
     });
 

--- a/public/mobile-app/src/lib/matomo.ts
+++ b/public/mobile-app/src/lib/matomo.ts
@@ -49,3 +49,12 @@ export function trackZone(zone: string, add: boolean) {
   window._paq = window._paq || [];
   window._paq.push(['trackEvent', 'Holidays zones', add ? 'add' : 'remove', zone]);
 }
+
+export function trackZoneCount(count: number) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window._paq = window._paq || [];
+  window._paq.push(['trackEvent', 'Holidays zones', 'count', '', count]);
+}

--- a/public/mobile-app/src/lib/matomo.ts
+++ b/public/mobile-app/src/lib/matomo.ts
@@ -40,3 +40,12 @@ export function trackPageView(title?: string) {
   }
   window._paq.push(['trackPageView']);
 }
+
+export function trackZone(zone: string, add: boolean) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window._paq = window._paq || [];
+  window._paq.push(['trackEvent', 'Holidays zones', add ? 'add' : 'remove', zone]);
+}

--- a/public/mobile-app/src/lib/notifications.test.ts
+++ b/public/mobile-app/src/lib/notifications.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { waitFor } from '@testing-library/svelte';
 import type { AppNotification } from '$lib/notifications';
@@ -27,6 +27,19 @@ describe('/notifications', () => {
       registerDevice: vi.fn().mockReturnValue({ id: 'fake-registration-id' }),
       unregisterDevice: vi.fn(() => true),
     }));
+
+    vi.mock('$env/static/public', async (importOriginal) => {
+      const original = (await importOriginal()) as Record<string, unknown>;
+      return Promise.resolve({
+        ...original,
+        PUBLIC_API_URL: 'https://localhost:8000',
+        PUBLIC_MATOMO_ENABLED: 'true',
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
   });
 
   describe('fetchAndStoreNotifications', () => {

--- a/public/mobile-app/src/lib/state/preferences.test.ts
+++ b/public/mobile-app/src/lib/state/preferences.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { Address } from '$lib/address';
 import type { CatalogItem } from '$lib/api-catalog';
+import * as matomoMethods from '$lib/matomo';
 import { Preferences } from '$lib/state/preferences';
 
 describe('/preferences.ts', () => {
@@ -376,6 +377,9 @@ describe('/preferences.ts', () => {
         const preferences1 = new Preferences([], []);
         const preferences2 = new Preferences(['Foo'], []);
         const preferences3 = new Preferences(['Foo', 'Bar'], []);
+        const trackZoneSpy = vi
+          .spyOn(matomoMethods, 'trackZone')
+          .mockResolvedValue(undefined);
 
         // When
         preferences1.addZone('Bar');
@@ -386,6 +390,7 @@ describe('/preferences.ts', () => {
         expect(preferences1.zones).toEqual(['Bar']);
         expect(preferences2.zones).toEqual(['Foo', 'Bar']);
         expect(preferences3.zones).toEqual(['Foo', 'Bar']);
+        expect(trackZoneSpy).toHaveBeenCalledWith('Bar', true);
       });
     });
 
@@ -395,6 +400,9 @@ describe('/preferences.ts', () => {
         const preferences1 = new Preferences([], []);
         const preferences2 = new Preferences(['Foo'], []);
         const preferences3 = new Preferences(['Foo', 'Bar'], []);
+        const trackZoneSpy = vi
+          .spyOn(matomoMethods, 'trackZone')
+          .mockResolvedValue(undefined);
 
         // When
         preferences1.removeZone('Bar');
@@ -405,6 +413,7 @@ describe('/preferences.ts', () => {
         expect(preferences1.zones).toEqual([]);
         expect(preferences2.zones).toEqual(['Foo']);
         expect(preferences3.zones).toEqual(['Foo']);
+        expect(trackZoneSpy).toHaveBeenCalledWith('Bar', false);
       });
     });
 

--- a/public/mobile-app/src/lib/state/preferences.test.ts
+++ b/public/mobile-app/src/lib/state/preferences.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { Address } from '$lib/address';
 import type { CatalogItem } from '$lib/api-catalog';
@@ -6,6 +6,10 @@ import * as matomoMethods from '$lib/matomo';
 import { Preferences } from '$lib/state/preferences';
 
 describe('/preferences.ts', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   describe('Preferences', () => {
     describe('fromJSON', () => {
       test('should init with values - empty values', async () => {
@@ -380,6 +384,9 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
+        const trackZoneCountSpy = vi
+          .spyOn(matomoMethods, 'trackZoneCount')
+          .mockResolvedValue(undefined);
 
         // When
         preferences1.addZone('Bar');
@@ -390,7 +397,12 @@ describe('/preferences.ts', () => {
         expect(preferences1.zones).toEqual(['Bar']);
         expect(preferences2.zones).toEqual(['Foo', 'Bar']);
         expect(preferences3.zones).toEqual(['Foo', 'Bar']);
-        expect(trackZoneSpy).toHaveBeenCalledWith('Bar', true);
+        expect(trackZoneSpy).toHaveBeenCalledTimes(2);
+        expect(trackZoneSpy).toHaveBeenNthCalledWith(1, 'Bar', true);
+        expect(trackZoneSpy).toHaveBeenNthCalledWith(2, 'Bar', true);
+        expect(trackZoneCountSpy).toHaveBeenCalledTimes(2);
+        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(1, 1);
+        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(2, 2);
       });
     });
 
@@ -403,6 +415,9 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
+        const trackZoneCountSpy = vi
+          .spyOn(matomoMethods, 'trackZoneCount')
+          .mockResolvedValue(undefined);
 
         // When
         preferences1.removeZone('Bar');
@@ -413,7 +428,11 @@ describe('/preferences.ts', () => {
         expect(preferences1.zones).toEqual([]);
         expect(preferences2.zones).toEqual(['Foo']);
         expect(preferences3.zones).toEqual(['Foo']);
-        expect(trackZoneSpy).toHaveBeenCalledWith('Bar', false);
+
+        expect(trackZoneSpy).toHaveBeenCalledTimes(1);
+        expect(trackZoneSpy).toHaveBeenNthCalledWith(1, 'Bar', false);
+        expect(trackZoneCountSpy).toHaveBeenCalledTimes(1);
+        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(1, 1);
       });
     });
 

--- a/public/mobile-app/src/lib/state/preferences.ts
+++ b/public/mobile-app/src/lib/state/preferences.ts
@@ -1,6 +1,7 @@
 import type { Address } from '$lib/address';
 import { zones } from '$lib/address';
 import type { CatalogItem } from '$lib/api-catalog';
+import { trackZone } from '$lib/matomo';
 import type { ToggleTag } from '$lib/types/components/toggletag';
 
 export type ZoneInfo = {
@@ -112,10 +113,12 @@ export class Preferences {
       return;
     }
     this._zones.push(zone);
+    trackZone(zone, true);
   }
 
   removeZone(zone: string) {
     this._zones = this._zones.filter((value) => zone !== value);
+    trackZone(zone, false);
   }
 
   getZoneInfos(userAddress: Address | undefined): ZoneInfo[] {

--- a/public/mobile-app/src/lib/state/preferences.ts
+++ b/public/mobile-app/src/lib/state/preferences.ts
@@ -1,7 +1,7 @@
 import type { Address } from '$lib/address';
 import { zones } from '$lib/address';
 import type { CatalogItem } from '$lib/api-catalog';
-import { trackZone } from '$lib/matomo';
+import { trackZone, trackZoneCount } from '$lib/matomo';
 import type { ToggleTag } from '$lib/types/components/toggletag';
 
 export type ZoneInfo = {
@@ -114,11 +114,13 @@ export class Preferences {
     }
     this._zones.push(zone);
     trackZone(zone, true);
+    trackZoneCount(this._zones.length);
   }
 
   removeZone(zone: string) {
     this._zones = this._zones.filter((value) => zone !== value);
     trackZone(zone, false);
+    trackZoneCount(this._zones.length);
   }
 
   getZoneInfos(userAddress: Address | undefined): ZoneInfo[] {

--- a/public/mobile-app/src/lib/state/preferences.ts
+++ b/public/mobile-app/src/lib/state/preferences.ts
@@ -118,6 +118,9 @@ export class Preferences {
   }
 
   removeZone(zone: string) {
+    if (!this._zones.includes(zone)) {
+      return;
+    }
     this._zones = this._zones.filter((value) => zone !== value);
     trackZone(zone, false);
     trackZoneCount(this._zones.length);


### PR DESCRIPTION
Fixes #750

Ici on utilise matomo, parce que jusqu'à présent on utilisait matomo côté frontend/svelte, et sentry côté backend.

On pourrait décider d'uniformiser à l'avenir, à discuter.