### PR TITLE
Load the DEBUG env var from the .env.local file (#905)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ will overload what's in the `.env` file.
 For example you'll need to overload the FranceConnect secrets for AMI in your
 `.env.local` file.
 
+At a minimum, you'll need a `.env.local` file with the following line, in order
+for the `.env.development` file with all the good default for local dev to be
+loaded:
+
+```ini
+DEBUG=true
+```
+
 On the front end, Vite uses dotenv to load additional environment variables
 from the following files in your environment directory, in this order:
 

--- a/ami/settings.py
+++ b/ami/settings.py
@@ -9,15 +9,19 @@ from dotenv import dotenv_values
 
 import vapid_keys
 
+CONFIG = {
+    **dotenv_values(".env"),
+    **dotenv_values(".env.local"),
+}
+
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG") == "true"
+DEBUG = CONFIG.get("DEBUG") == "true"
 print(f"Debug mode: {DEBUG}")
 
 dev_env_vars = dotenv_values(".env.development") if DEBUG else {}
 
 CONFIG = {
-    **dotenv_values(".env"),
-    **dotenv_values(".env.local"),
+    **CONFIG,
     **dev_env_vars,
     **os.environ,  # override loaded values with environment variables
 }


### PR DESCRIPTION
Fixes #905 (again)

Suite à la PR #909, et une discussion sur tchap avec @zebuline , il est préférable de charger la valeur de `DEBUG` du fichier `.env.local`.