### PR TITLE
front: track zone count on unmount only, rename counter (#961)

### DIFF
--- a/public/mobile-app/src/lib/components/modal/ZonePreferences.svelte
+++ b/public/mobile-app/src/lib/components/modal/ZonePreferences.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { mount, onMount, unmount } from 'svelte';
+  import { mount, onDestroy, onMount, unmount } from 'svelte';
   import { slide } from 'svelte/transition';
   import { goto } from '$app/navigation';
   import { Address } from '$lib/address';
@@ -9,6 +9,7 @@
     type ResponseFromGeoAPI,
   } from '$lib/citiesFromGeoAPIAndBAN';
   import Toggle from '$lib/components/Toggle.svelte';
+  import { trackZoneCount } from '$lib/matomo';
   import { Preferences, type ZoneInfo } from '$lib/state/preferences';
   import { userStore } from '$lib/state/User.svelte';
   import NavWithBackButton from './NavWithBackButton.svelte';
@@ -22,6 +23,7 @@
   let filteredCities: ResponseFromGeoAPI[] = $state([]);
   let cityApiHasError: boolean = $state(false);
   let zonesVisible: boolean = $state(true);
+  let zonesHasChanged: boolean = $state(false);
 
   interface Props {
     footerTarget?: HTMLElement | null;
@@ -77,6 +79,16 @@
         footerInstance = null;
       }
     };
+  });
+
+  onDestroy(() => {
+    if (zonesHasChanged) {
+      if (!userStore.connected) {
+        return;
+      }
+      const preferences = userStore.connected.identity.preferences;
+      trackZoneCount(preferences.zones.length);
+    }
   });
 
   const hideZones = async () => {
@@ -163,6 +175,7 @@
     }
     userStore.connected.setPreferences(preferences);
     refreshPreferences();
+    zonesHasChanged = true;
   };
 
   const removeAddress = async (id: string) => {

--- a/public/mobile-app/src/lib/components/modal/ZonePreferences.svelte.test.ts
+++ b/public/mobile-app/src/lib/components/modal/ZonePreferences.svelte.test.ts
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import * as navigationMethods from '$app/navigation';
 import { Address } from '$lib/address';
 import * as citiesFromGeoAPIAndBANMethods from '$lib/citiesFromGeoAPIAndBAN';
+import * as matomoMethods from '$lib/matomo';
 import { Preferences } from '$lib/state/preferences';
 import { userStore } from '$lib/state/User.svelte';
 import { mockUserIdentity, mockUserInfo } from '$tests/utils';
@@ -512,6 +513,51 @@ describe('/ZonePreferences.svelte', () => {
         expect(parsed?.preferences).toEqual(userStore.connected?.identity.preferences);
         expect(spy).toHaveBeenCalledWith();
       });
+    });
+  });
+
+  describe('Zones tracking on unmount', () => {
+    test('should not track zones count has there is no change', async () => {
+      // Given
+      await userStore.login(mockUserInfo);
+      const onClose = vi.fn();
+      const trackZoneCountSpy = vi
+        .spyOn(matomoMethods, 'trackZoneCount')
+        .mockResolvedValue(undefined);
+      const { unmount } = render(ZonePreferences, { props: { onClose } });
+
+      // When
+      unmount();
+
+      // Then
+      expect(trackZoneCountSpy).toHaveBeenCalledTimes(0);
+    });
+    test('should not track zones count', async () => {
+      // Given
+      await userStore.login(mockUserInfo);
+      const onClose = vi.fn();
+      const trackZoneCountSpy = vi
+        .spyOn(matomoMethods, 'trackZoneCount')
+        .mockResolvedValue(undefined);
+      const { unmount } = render(ZonePreferences, { props: { onClose } });
+
+      // When
+      const toggleInputMartinique = screen.getByTestId('Martinique');
+      await fireEvent.click(toggleInputMartinique); // add
+      const toggleInputZoneC = screen.getByTestId('Zone C');
+      await fireEvent.click(toggleInputZoneC); // remove
+
+      unmount();
+
+      // Then
+      expect(userStore.connected?.identity.preferences.zones).toEqual([
+        'Zone A',
+        'Zone B',
+        'Corse',
+        'Martinique',
+      ]);
+      expect(trackZoneCountSpy).toHaveBeenCalledTimes(1);
+      expect(trackZoneCountSpy).toHaveBeenCalledWith(4);
     });
   });
 });

--- a/public/mobile-app/src/lib/matomo.ts
+++ b/public/mobile-app/src/lib/matomo.ts
@@ -56,5 +56,5 @@ export function trackZoneCount(count: number) {
   }
 
   window._paq = window._paq || [];
-  window._paq.push(['trackEvent', 'Holidays zones', 'count', '', count]);
+  window._paq.push(['trackEvent', 'Holidays zones', 'number_of_zones', '', count]);
 }

--- a/public/mobile-app/src/lib/state/preferences.test.ts
+++ b/public/mobile-app/src/lib/state/preferences.test.ts
@@ -450,9 +450,6 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
-        const trackZoneCountSpy = vi
-          .spyOn(matomoMethods, 'trackZoneCount')
-          .mockResolvedValue(undefined);
 
         // When
         preferences1.addZone('Bar');
@@ -466,9 +463,6 @@ describe('/preferences.ts', () => {
         expect(trackZoneSpy).toHaveBeenCalledTimes(2);
         expect(trackZoneSpy).toHaveBeenNthCalledWith(1, 'Bar', true);
         expect(trackZoneSpy).toHaveBeenNthCalledWith(2, 'Bar', true);
-        expect(trackZoneCountSpy).toHaveBeenCalledTimes(2);
-        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(1, 1);
-        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(2, 2);
       });
     });
 
@@ -480,9 +474,6 @@ describe('/preferences.ts', () => {
         const preferences3 = new Preferences(['Foo', 'Bar'], []);
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
-          .mockResolvedValue(undefined);
-        const trackZoneCountSpy = vi
-          .spyOn(matomoMethods, 'trackZoneCount')
           .mockResolvedValue(undefined);
 
         // When
@@ -496,8 +487,6 @@ describe('/preferences.ts', () => {
         expect(preferences3.zones).toEqual(['Foo']);
         expect(trackZoneSpy).toHaveBeenCalledTimes(1);
         expect(trackZoneSpy).toHaveBeenNthCalledWith(1, 'Bar', false);
-        expect(trackZoneCountSpy).toHaveBeenCalledTimes(1);
-        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(1, 1);
       });
     });
 
@@ -552,9 +541,6 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
-        const trackZoneCountSpy = vi
-          .spyOn(matomoMethods, 'trackZoneCount')
-          .mockResolvedValue(undefined);
 
         // When
         preferences1.addAddress(address3);
@@ -574,9 +560,6 @@ describe('/preferences.ts', () => {
         expect(trackZoneSpy).toHaveBeenCalledTimes(2);
         expect(trackZoneSpy).toHaveBeenNthCalledWith(1, 'Réunion', true);
         expect(trackZoneSpy).toHaveBeenNthCalledWith(2, 'Réunion', true);
-        expect(trackZoneCountSpy).toHaveBeenCalledTimes(2);
-        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(1, 1);
-        expect(trackZoneCountSpy).toHaveBeenNthCalledWith(2, 4);
       });
     });
 
@@ -643,9 +626,6 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
-        const trackZoneCountSpy = vi
-          .spyOn(matomoMethods, 'trackZoneCount')
-          .mockResolvedValue(undefined);
 
         // When
         preferences1.removeAddress(address3);
@@ -666,7 +646,6 @@ describe('/preferences.ts', () => {
         expect(preferences5.zones).toEqual(['Zone A', 'Zone B', 'Zone C', 'Réunion']);
         expect(preferences5.addresses).toEqual([address1, address2, address4]);
         expect(trackZoneSpy).toHaveBeenCalledTimes(0);
-        expect(trackZoneCountSpy).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -698,9 +677,6 @@ describe('/preferences.ts', () => {
         const trackZoneSpy = vi
           .spyOn(matomoMethods, 'trackZone')
           .mockResolvedValue(undefined);
-        const trackZoneCountSpy = vi
-          .spyOn(matomoMethods, 'trackZoneCount')
-          .mockResolvedValue(undefined);
 
         // When
         preferences1.clearAddresses();
@@ -712,7 +688,6 @@ describe('/preferences.ts', () => {
         expect(preferences2.zones).toEqual(['Zone A', 'Zone B', 'Zone C']);
         expect(preferences2.addresses).toEqual([]);
         expect(trackZoneSpy).toHaveBeenCalledTimes(0);
-        expect(trackZoneCountSpy).toHaveBeenCalledTimes(0);
       });
     });
 

--- a/public/mobile-app/src/lib/state/preferences.ts
+++ b/public/mobile-app/src/lib/state/preferences.ts
@@ -1,7 +1,7 @@
 import type { Address as AddressType } from '$lib/address';
 import { Address, zones } from '$lib/address';
 import type { CatalogItem } from '$lib/api-catalog';
-import { trackZone, trackZoneCount } from '$lib/matomo';
+import { trackZone } from '$lib/matomo';
 import type { ToggleTag } from '$lib/types/components/toggletag';
 
 export type ZoneInfo = {
@@ -123,7 +123,6 @@ export class Preferences {
     }
     this._zones.push(zone);
     trackZone(zone, true);
-    trackZoneCount(this._zones.length);
   }
 
   removeZone(zone: string) {
@@ -132,7 +131,6 @@ export class Preferences {
     }
     this._zones = this._zones.filter((value) => zone !== value);
     trackZone(zone, false);
-    trackZoneCount(this._zones.length);
   }
 
   addAddress(address: AddressType) {


### PR DESCRIPTION
fixes #961 