### PR TITLE
Utiliser django-tasks-db pour avoir un vrai backend asynchrone et ne plus avoir de timeout sur les notifications des partenaires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,7 @@ delete-published-scheduled-notifications:
 .PHONY: replicate-anonymized-data
 replicate-anonymized-data:
 	$(RUN) python manage.py replicate-anonymized-data
+
+.PHONY: db-worker
+db-worker:
+	$(RUN) python manage.py db_worker

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bash ./bin/start.sh
+worker: bash ./bin/worker.sh

--- a/ami/conftest.py
+++ b/ami/conftest.py
@@ -23,7 +23,12 @@ from ami.user.utils import build_fc_hash
 
 
 @pytest.fixture
-def app(django_app):
+def dummy_tasks(settings):
+    settings.TASKS = {"default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}}
+
+
+@pytest.fixture
+def app(django_app, dummy_tasks):
     cache.clear()
     yield django_app
 

--- a/ami/notification/api_views.py
+++ b/ami/notification/api_views.py
@@ -210,7 +210,7 @@ def partner_create_notification(request: Request) -> Response[NotificationRespon
         )
         if created:
             transaction.on_commit(
-                partial(push_notification.enqueue, str(notification.id), try_push)
+                partial(push_notification.enqueue, str(notification.id), try_push)  # type: ignore[union-attr]
             )
 
     sentry.add_counter("notification.request.processed")

--- a/ami/notification/api_views.py
+++ b/ami/notification/api_views.py
@@ -1,10 +1,12 @@
 import os
 import uuid
+from functools import partial
 from typing import cast
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.conf import settings
+from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
@@ -198,15 +200,19 @@ def partner_create_notification(request: Request) -> Response[NotificationRespon
     data.pop("recipient_fc_hash")
     if data["content_icon"] is None:
         data["content_icon"] = current_partner.icon or "fr-icon-mail-star-line"
-    notification, created = Notification.objects.get_or_create(
-        user_id=user.id,
-        partner_id=current_partner.id,
-        defaults={"send_status": notification_send_status},
-        **data,
-    )
 
-    if created:
-        push_notification.enqueue(str(notification.id), try_push)
+    with transaction.atomic():
+        notification, created = Notification.objects.get_or_create(
+            user_id=user.id,
+            partner_id=current_partner.id,
+            defaults={"send_status": notification_send_status},
+            **data,
+        )
+        if created:
+            transaction.on_commit(
+                partial(push_notification.enqueue, str(notification.id), try_push)
+            )
+
     sentry.add_counter("notification.request.processed")
 
     response_data = {

--- a/ami/notification/tasks.py
+++ b/ami/notification/tasks.py
@@ -1,14 +1,11 @@
 from asgiref.sync import async_to_sync
-from django.tasks import Task, task  # type: ignore[import-untyped]
+from django.tasks import task  # type: ignore[import-untyped]
 
 from ami.notification.models import Notification
 from ami.notification.push import push
 
 
-def _push_notification(notification_id: str, try_push: bool) -> None:
+@task
+def push_notification(notification_id: str, try_push: bool) -> None:
     notification = Notification.objects.get(id=notification_id)
     async_to_sync(push)(notification, try_push)
-
-
-# Using the @task decorator makes pyright complain, so we do it this way with explicit type annotation
-push_notification: Task = task(_push_notification)

--- a/ami/notification/tests/api/test_partner_notifications.py
+++ b/ami/notification/tests/api/test_partner_notifications.py
@@ -7,6 +7,7 @@ import pytest
 import webpush as webpush_lib
 from asgiref.sync import sync_to_async
 from channels.testing.websocket import WebsocketCommunicator
+from django.test import TestCase
 from django.utils.timezone import now
 from pytest_httpx import HTTPXMock
 from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED
@@ -121,7 +122,7 @@ def test_create_mobile_notification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     send_mock = Mock()
-    monkeypatch.setattr("ami.notification.push.messaging.send", send_mock)
+    monkeypatch.setattr("firebase_admin.messaging.send", send_mock)
     notification_data = {
         "recipient_fc_hash": mobile_registration.user.fc_hash,
         "content_title": "Brouillon de nouvelle demande de démarche d'OTV",
@@ -138,7 +139,8 @@ def test_create_mobile_notification(
         "send_date": "2025-11-27T10:55:00.000Z",
         "try_push": True,
     }
-    response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
+    with TestCase.captureOnCommitCallbacks(execute=True):
+        response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
     assert response.status_code == HTTP_201_CREATED
     assert Notification.objects.count() == 2
     notification2 = Notification.objects.latest("created_at")
@@ -447,7 +449,8 @@ def test_create_notification_when_registration_gone(
         "content_title": "Brouillon de nouvelle demande de démarche d'OTV",
         "content_body": "Merci d'avoir initié votre demande",
     }
-    response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
+    with TestCase.captureOnCommitCallbacks(execute=True):
+        response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
     assert response.status_code == HTTP_201_CREATED
     assert Notification.objects.count() == 1
     assert httpx_mock.get_request()
@@ -646,7 +649,8 @@ def test_create_notification_duplicated_payload_with_push(
         "content_body": "Merci d'avoir initié votre demande",
     }
 
-    response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
+    with TestCase.captureOnCommitCallbacks(execute=True):
+        response = app.post("/api/v1/notifications", notification_data, headers=partner_auth)
     assert response.status_code == HTTP_201_CREATED
     assert Notification.objects.count() == 1
     notification = Notification.objects.get()

--- a/ami/settings.py
+++ b/ami/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "ami.amidsfr",
     "django.forms",
     "sass_processor",
+    "django_tasks_db",
     "ami.authentication",
     "ami.fi",
     "ami.notification",
@@ -180,8 +181,7 @@ LOGOUT_REDIRECT_URL = "/agent-admin/"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Tasks
-# TODO: use a real task backend in production
-TASKS = {"default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}}
+TASKS = {"default": {"BACKEND": "django_tasks_db.DatabaseBackend"}}
 
 # Password validation
 # https://docs.djangoproject.com/en/6.0/ref/settings/#auth-password-validators

--- a/bin/worker.sh
+++ b/bin/worker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+PORT="${PORT:-8000}"
+HOST="${HOST:-0.0.0.0}"
+
+if [ "$APP" == "ami-back-prod" ]
+then
+  # We don't want to use the FranceConnect proxy in production
+  export PUBLIC_FC_PROXY_BASE_URL=""
+fi
+
+if [ ! -z "$CONTAINER" ]
+then
+  # We're running on Scalingo
+  # Rebuild the FCM secret json keys file from the env vars, see the section in CONTRIBUTING.md
+  echo "$FCM_KEYS_FILE" | base64 -d > "$GOOGLE_APPLICATION_CREDENTIALS"
+  # Don't use uv
+  RUN=""
+fi
+
+make db-worker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "django-dsfr>=3.3.1",
     "django-sass-processor>=1.4.2",
     "django-stubs[compatible-mypy]>=5.2.9",
+    "django-tasks-db>=0.12.0",
     "djangorestframework>=3.16.1",
     "djangorestframework-dataclasses>=1.4.0",
     "drf-spectacular>=0.29.0",

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ dependencies = [
     { name = "django-dsfr" },
     { name = "django-sass-processor" },
     { name = "django-stubs", extra = ["compatible-mypy"] },
+    { name = "django-tasks-db" },
     { name = "djangorestframework" },
     { name = "djangorestframework-dataclasses" },
     { name = "drf-spectacular" },
@@ -71,6 +72,7 @@ requires-dist = [
     { name = "django-dsfr", specifier = ">=3.3.1" },
     { name = "django-sass-processor", specifier = ">=1.4.2" },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.2.9" },
+    { name = "django-tasks-db", specifier = ">=0.12.0" },
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "djangorestframework-dataclasses", specifier = ">=1.4.0" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },
@@ -670,6 +672,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/03/9c2be939490d2282328db4611bc5956899f5ff7eabc3e88bd4b964a87373/django_stubs_ext-5.2.9.tar.gz", hash = "sha256:6db4054d1580657b979b7d391474719f1a978773e66c7070a5e246cd445a25a9", size = 6497, upload-time = "2026-01-20T23:58:59.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/f7/0d5f7d7e76fe972d9f560f687fdc0cab4db9e1624fd90728ca29b4ed7a63/django_stubs_ext-5.2.9-py3-none-any.whl", hash = "sha256:230c51575551b0165be40177f0f6805f1e3ebf799b835c85f5d64c371ca6cf71", size = 9974, upload-time = "2026-01-20T23:58:58.438Z" },
+]
+
+[[package]]
+name = "django-tasks"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/6e/34d4e77bb7951e5a5acbd846f43240f062c68bb04d9c246cb446a55d4cbc/django_tasks-0.12.0.tar.gz", hash = "sha256:58be66c1e487da32a3ce7320bd1949d0d1dc381b9004819f92591eb37fb2c1b8", size = 15445, upload-time = "2026-02-06T16:15:33.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/e7/40c45768e84efd77e3ae6ffdcd2b5540011036cbb00c6df6ef2a2ad69551/django_tasks-0.12.0-py3-none-any.whl", hash = "sha256:ffcc1d7bdfad3bc5ef9c2d498596c6546484c9ec6b182fb9709c691eb66a8709", size = 15758, upload-time = "2026-02-06T16:15:32.168Z" },
+]
+
+[[package]]
+name = "django-tasks-db"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "django-tasks" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/25/bc21ad4a610634f0a66f4faea4522eed26b55dbd50c4ac853128d24091d3/django_tasks_db-0.12.0.tar.gz", hash = "sha256:314d486b8c1786705b4afaf03dadaf0b1b104163acce9c5d9c9bb2aef205c501", size = 26724, upload-time = "2026-02-06T16:54:33.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/1c/e14198615e22df28b333540f2e506d6ddef7aff16d510818e94ebc01440c/django_tasks_db-0.12.0-py3-none-any.whl", hash = "sha256:69e3a1edcbf1efeeb1268da465e8ea5296ddd80834719769acc719b82da2d62e", size = 28832, upload-time = "2026-02-06T16:54:31.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
fixes #956 