### PR TITLE
fix: génération du token de préremplissage: les champs ne sont pas obligatoires

### DIFF
--- a/ami/service/serializers.py
+++ b/ami/service/serializers.py
@@ -13,11 +13,11 @@ class ServicesSerializer(DataclassSerializer):
 
 
 class OTVJWTTokenSerializer(serializers.Serializer):
-    preferred_username = serializers.CharField(allow_blank=True, required=False)
-    email = serializers.CharField(allow_blank=True, required=False)
-    address_city = serializers.CharField(allow_blank=True, required=False)
-    address_postcode = serializers.CharField(allow_blank=True, required=False)
-    address_name = serializers.CharField(allow_blank=True, required=False)
+    preferred_username = serializers.CharField(allow_blank=True, required=False, default="")
+    email = serializers.CharField(allow_blank=True, required=False, default="")
+    address_city = serializers.CharField(allow_blank=True, required=False, default="")
+    address_postcode = serializers.CharField(allow_blank=True, required=False, default="")
+    address_name = serializers.CharField(allow_blank=True, required=False, default="")
 
     @classmethod
     def get_parameter_value(cls, *, validated_data, user):

--- a/ami/service/tests/test_services_item_parameters.py
+++ b/ami/service/tests/test_services_item_parameters.py
@@ -62,8 +62,21 @@ def test_get_services_items_parameters_otv_jwt_token(
 def test_get_services_items_parameters_otv_jwt_token_missing_payload(
     app,
     user: User,
+    monkeypatch: pytest.MonkeyPatch,
+    settings,
 ) -> None:
     login(app, user)
+
+    settings.PARTNERS_PSL_OTV_JWT_CERT_PFX_B64 = "foo"
+    settings.PARTNERS_PSL_OTV_JWE_PUBLIC_KEY = "bar"
+
+    def mock_generate_identity_token(*args: Any, **kwargs: Any):
+        return "fake-identity-token"
+
+    monkeypatch.setattr(
+        "ami.service.serializers.generate_identity_token",
+        mock_generate_identity_token,
+    )
 
     parameters_data = {
         "parameters": [
@@ -74,15 +87,28 @@ def test_get_services_items_parameters_otv_jwt_token_missing_payload(
         ]
     }
     response = app.post_json("/api/v1/users/data/services/item/parameters", parameters_data)
-    assert response.json == {"data": {"otv_jwt_token": ""}}
+    assert response.json == {"data": {"otv_jwt_token": "fake-identity-token"}}
 
 
 @pytest.mark.django_db
 def test_get_services_items_parameters_otv_jwt_token_empty_fields(
     app,
     user: User,
+    monkeypatch: pytest.MonkeyPatch,
+    settings,
 ) -> None:
     login(app, user)
+
+    settings.PARTNERS_PSL_OTV_JWT_CERT_PFX_B64 = "foo"
+    settings.PARTNERS_PSL_OTV_JWE_PUBLIC_KEY = "bar"
+
+    def mock_generate_identity_token(*args: Any, **kwargs: Any):
+        return "fake-identity-token"
+
+    monkeypatch.setattr(
+        "ami.service.serializers.generate_identity_token",
+        mock_generate_identity_token,
+    )
 
     parameters_data = {
         "parameters": [
@@ -99,7 +125,7 @@ def test_get_services_items_parameters_otv_jwt_token_empty_fields(
         ]
     }
     response = app.post_json("/api/v1/users/data/services/item/parameters", parameters_data)
-    assert response.json == {"data": {"otv_jwt_token": ""}}
+    assert response.json == {"data": {"otv_jwt_token": "fake-identity-token"}}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
fixes #1070 