### PR TITLE
Séparer les rapidocs des endpoint publics et privés (#876)

### DIFF
--- a/ami/api/urls.py
+++ b/ami/api/urls.py
@@ -42,4 +42,18 @@ urlpatterns = [
         ),
         name="rapidoc",
     ),
+    path("schema/internal-apis", SpectacularAPIView.as_view(), name="internal-apis-schema"),
+    path(
+        "schema/internal-apis/rapidoc",
+        TemplateView.as_view(
+            template_name="rapidoc.html",
+            extra_context={"schema_url": "/schema/internal-apis"},
+        ),
+        name="internal-apis-rapidoc",
+    ),
+    path(
+        "schema/internal-apis/swagger",
+        SpectacularSwaggerView.as_view(url_name="internal-apis-schema"),
+        name="swagger",
+    ),
 ]

--- a/ami/notification/api_views.py
+++ b/ami/notification/api_views.py
@@ -158,6 +158,7 @@ def delete_scheduled_notification(request: Request) -> Response:
 
 @extend_schema(
     methods=["POST"],
+    tags=["API partenaires"],
     request=PartnerNotificationCreateSerializer,
     responses={
         200: NotificationResponseSerializer,

--- a/ami/notification/api_views_v2.py
+++ b/ami/notification/api_views_v2.py
@@ -83,6 +83,7 @@ def _partner_create_event(request: Request, data: dict):
         200: NotificationResponseSerializer,
         201: NotificationResponseSerializer,
     },
+    tags=["API partenaires"],
 )
 @api_view(["PUT"])
 @authentication_classes([PartnerBasicAuthentication])

--- a/ami/partner/api_views.py
+++ b/ami/partner/api_views.py
@@ -55,7 +55,10 @@ def generate_partner_url(request):
 
 
 @extend_schema(
-    responses=inline_serializer("PartnerPublicKeyResponse", {"public_key": serializers.CharField()})
+    responses=inline_serializer(
+        "PartnerPublicKeyResponse", {"public_key": serializers.CharField()}
+    ),
+    tags=["API partenaires"],
 )
 @api_view(["GET"])
 def get_partner_public_key(request) -> Response[dict[str, str]]:

--- a/ami/settings.py
+++ b/ami/settings.py
@@ -227,7 +227,7 @@ REST_FRAMEWORK = {
 }
 SPECTACULAR_SETTINGS = {
     "TITLE": "AMI API",
-    "DESCRIPTION": "API de l'Application Mobile Interminitérielle",
+    "DESCRIPTION": "API de l’Application Mobile Interministérielle",
     "VERSION": "1.0.0",
 }
 

--- a/ami/settings.py
+++ b/ami/settings.py
@@ -225,10 +225,15 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": [],  # Set it explicitely to empty, because by default it has basic auth and bypasses our own partner auth decorators.
 }
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "AMI API",
     "DESCRIPTION": "API de l’Application Mobile Interministérielle",
     "VERSION": "1.0.0",
+    "POSTPROCESSING_HOOKS": [
+        "ami.utils.schemas.custom_postprocessing_hook",
+        "drf_spectacular.hooks.postprocess_schema_enums",
+    ],
 }
 
 # Cors

--- a/ami/utils/schemas.py
+++ b/ami/utils/schemas.py
@@ -2,6 +2,10 @@ import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Dict, Optional
+
+from django.http import HttpRequest
+from drf_spectacular.generators import SchemaGenerator
 
 
 class TimeUnit(str, Enum):
@@ -46,3 +50,23 @@ class MonthlyExpiration(ExpirationRule):
             return datetime.datetime(
                 year=now.year + 1, month=1, day=1, tzinfo=datetime.timezone.utc
             )
+
+
+def custom_postprocessing_hook(
+    result: Dict[str, Any],
+    generator: "SchemaGenerator",
+    request: Optional["HttpRequest"],
+    public: bool,
+) -> Dict[str, Any]:
+    def is_partner_api(path: str) -> bool:
+        return any(
+            x for x in result["paths"][path].values() if "API partenaires" in (x.get("tags") or [])
+        )
+
+    if request and request.path == "/schema/internal-apis":
+        result["info"]["title"] = "AMI - Internal APIs"
+        result["paths"] = {x: y for x, y in result["paths"].items() if not is_partner_api(x)}
+    else:
+        result["paths"] = {x: y for x, y in result["paths"].items() if is_partner_api(x)}
+
+    return result

--- a/ami/utils/tests/test_schema.py
+++ b/ami/utils/tests/test_schema.py
@@ -1,0 +1,12 @@
+def test_schema(app):
+    resp = app.get("/schema")
+    assert "/api/v1/notifications" in resp.text
+    assert "/dev-utils/" not in resp.text
+    assert 'spec-url="/schema"' in app.get("/schema/rapidoc")
+    assert 'url: "/schema"' in app.get("/schema/swagger")
+
+    resp = app.get("/schema/internal-apis")
+    assert "/api/v1/notifications" not in resp.text
+    assert "/dev-utils/" in resp.text
+    assert 'spec-url="/schema/internal-apis"' in app.get("/schema/internal-apis/rapidoc")
+    assert 'url: "/schema/internal\\u002Dapis"' in app.get("/schema/internal-apis/swagger")


### PR DESCRIPTION
Fixes #876.

drf-spectacular n'offre pas de possibilité de ranger les API en plusieurs schémas (ensuite visualisés via rapidoc/swagger), leur suggestion est d'utiliser un hook de post-traitement (cf https://github.com/tfranzel/drf-spectacular/issues/221), cette PR fait ça, en classifiant les API partenaire via l'attribut tags (qui par défaut est généré à partir du chemin, donc "api", "dev-utils", etc.) puis en exploitant ça pour filtrer les chemins exposés dans le schéma.