### PR TITLE
Retour #940 : le item_parent_partner_id n'est pas obligatoire, il devrait être valorisé au partner id de l'appelant si besoin.

### DIFF
--- a/ami/notification/api_views_v2.py
+++ b/ami/notification/api_views_v2.py
@@ -102,7 +102,7 @@ def _partner_create_event(request: Request, data: dict):
 @authentication_classes([PartnerBasicAuthentication])
 @permission_classes([IsPartnerAuthenticated])
 def partner_create_event(request: Request) -> Response[NotificationResponseSerializer]:
-    serializer = PartnerEventCreateSerializerV2(data=request.data)
+    serializer = PartnerEventCreateSerializerV2(data=request.data, partner=request.ami_partner)
     try:
         serializer.is_valid(raise_exception=True)
     except serializers.ValidationError:

--- a/ami/notification/serializers.py
+++ b/ami/notification/serializers.py
@@ -251,6 +251,10 @@ class PartnerEventCreateSerializerV2(PartnerEventCreateMixin, serializers.Serial
         help_text="Indique si le système doit essayer de déclencher une Notification Push sur les terminaux de l'usager",
     )
 
+    def __init__(self, *args, **kwargs):
+        self.partner = kwargs.pop("partner", None)
+        super().__init__(*args, **kwargs)
+
     def validate_item_parent_partner_id(self, value):
         if value:
             try:
@@ -269,7 +273,7 @@ class PartnerEventCreateSerializerV2(PartnerEventCreateMixin, serializers.Serial
         has_item_parent_fields = any(
             bool(v) for k, v in attrs.items() if k.startswith("item_parent_")
         )
-        item_parent_fields = ["item_parent_partner_id", "item_parent_type", "item_parent_id"]
+        item_parent_fields = ["item_parent_type", "item_parent_id"]
         validation_errors = {}
         if has_item_parent_fields:
             validation_errors = {
@@ -279,5 +283,9 @@ class PartnerEventCreateSerializerV2(PartnerEventCreateMixin, serializers.Serial
             }
         if validation_errors:
             raise serializers.ValidationError(validation_errors)
+
+        if not attrs.get("item_parent_partner_id") and has_item_parent_fields:
+            # default partner for parent item is current partner
+            attrs["item_parent_partner_id"] = self.partner.id
 
         return attrs

--- a/ami/notification/tests/api/v2/test_partner_events.py
+++ b/ami/notification/tests/api/v2/test_partner_events.py
@@ -905,10 +905,12 @@ def test_create_event_send_ko_with_400_when_required_item_parent_fields_are_miss
     app,
     user: User,
     consent: Consent,
+    partner: Partner,
     partner_dn: Partner,
     partner_auth: dict[str, str],
 ) -> None:
-    item_parent_fields = ["item_parent_partner_id", "item_parent_type", "item_parent_id"]
+    item_parent_fields = ["item_parent_type", "item_parent_id"]
+    item_optional_parent_fields = ["item_parent_partner_id"]
     item_parent_field_values = {
         "item_parent_partner_id": "dinum-dn",
         "item_parent_type": "JeDéménage",
@@ -927,7 +929,7 @@ def test_create_event_send_ko_with_400_when_required_item_parent_fields_are_miss
         "item_milestone_end_date": "2026-01-02T23:00:00.000Z",
         "item_canal": "ami",
     }
-    for field in item_parent_fields:
+    for field in item_parent_fields + item_optional_parent_fields:
         data = {k: v for k, v in event_data.items()}
         data.update(
             {
@@ -940,6 +942,18 @@ def test_create_event_send_ko_with_400_when_required_item_parent_fields_are_miss
             for f in item_parent_fields
             if f != field
         }
+
+    event_data.update(
+        {
+            "item_parent_type": "JeDéménage",
+            "item_parent_id": "B-7-CGFD6SVYT",
+        }
+    )
+    response = app.put("/api/v2/event", event_data, headers=partner_auth)
+    assert response.status_code == HTTP_201_CREATED
+    assert Notification.objects.count() == 1
+    notification = Notification.objects.get()
+    assert notification.item_parent_partner == partner
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
fixes #1262